### PR TITLE
Add TypeScript declaration + generated JSON Schema

### DIFF
--- a/.mdn-spec-links.schema.json
+++ b/.mdn-spec-links.schema.json
@@ -1,0 +1,279 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/MDNSpecLink",
+  "definitions": {
+    "MDNSpecLink": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Feature"
+        }
+      },
+      "description": "Each top-level entry in our data is an object with a single key: A\nfragment ID from a spec. Each top-level entry associates its spec\nfragment ID with one or more objects holding data about a feature."
+    },
+    "Feature": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the feature (interface, method, or property name); from BCD."
+        },
+        "filename": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Filename of the BCD file containing the data for the feature."
+        },
+        "title": {
+          "type": "string",
+          "description": "Title of the MDN article for the feature."
+        },
+        "slug": {
+          "type": "string",
+          "description": "Slug (URL path) of the MDN article for the feature."
+        },
+        "summary": {
+          "type": "string",
+          "description": "First paragraph or \"seoSummary\" of the MDN article for the feature."
+        },
+        "engines": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EngineNames"
+          },
+          "description": "Names of engines with support for the feature that conforms to the\nspec (that is, un-prefixed and not under an alternative name —\nthough possibly requiring a runtime flag or preference to be set)."
+        },
+        "altname": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EngineNames"
+          },
+          "description": "Names of engines with support for the feature implemented under a\nwholly different name (in contrast to just being prefixed)."
+        },
+        "needsflag": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EngineNames"
+          },
+          "description": "Names of engines with support for the feature that requires setting\na runtime flag or preference."
+        },
+        "partial": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EngineNames"
+          },
+          "description": "Names of engines with support for the feature that differs from the\nspec in a way that may cause compatibility problems."
+        },
+        "prefixed": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EngineNames"
+          },
+          "description": "Names of engines with support for the feature that requires adding\na prefix to the standard feature name defined in the spec."
+        },
+        "support": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SupportBlock"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Per-browser data about support for the feature."
+        },
+        "caniuse": {
+          "type": "object",
+          "properties": {
+            "feature": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "feature",
+            "title"
+          ],
+          "additionalProperties": false,
+          "description": "The caniuse.com shortname for the feature, along with the title of\nthe caniuse.com table (page) for the feature."
+        }
+      },
+      "required": [
+        "name",
+        "filename",
+        "title",
+        "slug",
+        "summary",
+        "engines",
+        "support"
+      ],
+      "additionalProperties": false,
+      "description": "Each object for a feature has data from the MDN article for the feature,\nalong with data from BCD https://github.com/mdn/browser-compat-data/."
+    },
+    "EngineNames": {
+      "type": "string",
+      "enum": [
+        "blink",
+        "gecko",
+        "webkit"
+      ]
+    },
+    "SupportBlock": {
+      "type": "object",
+      "properties": {
+        "chrome": {
+          "$ref": "#/definitions/SupportDetails"
+        },
+        "chrome_android": {
+          "$ref": "#/definitions/SupportDetails"
+        },
+        "edge": {
+          "$ref": "#/definitions/SupportDetails"
+        },
+        "edge_blink": {
+          "$ref": "#/definitions/SupportDetails"
+        },
+        "firefox": {
+          "$ref": "#/definitions/SupportDetails"
+        },
+        "firefox_android": {
+          "$ref": "#/definitions/SupportDetails"
+        },
+        "ie": {
+          "$ref": "#/definitions/SupportDetails"
+        },
+        "nodejs": {
+          "$ref": "#/definitions/SupportDetails"
+        },
+        "opera": {
+          "$ref": "#/definitions/SupportDetails"
+        },
+        "opera_android": {
+          "$ref": "#/definitions/SupportDetails"
+        },
+        "qq_android": {
+          "$ref": "#/definitions/SupportDetails"
+        },
+        "safari": {
+          "$ref": "#/definitions/SupportDetails"
+        },
+        "safari_ios": {
+          "$ref": "#/definitions/SupportDetails"
+        },
+        "samsunginternet_android": {
+          "$ref": "#/definitions/SupportDetails"
+        },
+        "uc_android": {
+          "$ref": "#/definitions/SupportDetails"
+        },
+        "uc_chinese_android": {
+          "$ref": "#/definitions/SupportDetails"
+        },
+        "webview_android": {
+          "$ref": "#/definitions/SupportDetails"
+        }
+      },
+      "additionalProperties": false
+    },
+    "SupportDetails": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SupportStatement"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SupportStatement"
+          }
+        }
+      ]
+    },
+    "SupportStatement": {
+      "type": "object",
+      "properties": {
+        "version_added": {
+          "type": [
+            "string",
+            "boolean",
+            "null"
+          ],
+          "description": "Either: (1) a browser version number (the first version of the\nbrowser to add support for the feature), or (2) boolean true to\nindicate just that the browser supports the feature (but the first\nversion to add support for it is unknown), or (3) boolean false to\nindicate the browser doesn't support the feature, or else (4) null\nto indicate it's unknown whether the browser supports the feature."
+        },
+        "version_removed": {
+          "type": [
+            "string",
+            "boolean",
+            "null"
+          ],
+          "description": "Either: (1) a browser version number (the version of the browser\nwhich dropped support for the feature), or (2) boolean true to\nindicate just that the feature was dropped from the browser (but the\nfirst version to drop support for it is unknown). (Boolean false and\nnull are also allowed as values, but the semantics are undefined.)"
+        },
+        "alternative_name": {
+          "type": "string",
+          "description": "Alternative name for the feature, for cases of a feature implemented\nunder a wholly different name (in contrast to just being prefixed)."
+        },
+        "flags": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Flag"
+          },
+          "description": "Data about flags needed to enable support for the feature."
+        },
+        "notes": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
+          "description": "Additional/noteworthy information about support for the feature."
+        },
+        "partial_implementation": {
+          "type": "boolean",
+          "description": "Boolean indicating whether support for the feature deviates from the\nspecification in a way that may cause compatibility problems."
+        },
+        "prefix": {
+          "type": "string",
+          "description": "Prefix that must be added to the feature name defined in the spec in\norder to enable support. Includes any leading/trailing dashes."
+        }
+      },
+      "required": [
+        "version_added"
+      ],
+      "additionalProperties": false
+    },
+    "Flag": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the flag or preference that must be set in order to\nenable support for the feature."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "preference",
+            "runtime_flag"
+          ]
+        },
+        "value_to_set": {
+          "type": "string",
+          "description": "The value to which the specified flag must be set in order to enable\nsupport for the feature."
+        }
+      },
+      "required": [
+        "name",
+        "type"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/.mdn-spec-links.schema.json
+++ b/.mdn-spec-links.schema.json
@@ -41,42 +41,42 @@
         "engines": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/EngineNames"
+            "$ref": "#/definitions/Engines"
           },
           "description": "Names of engines with support for the feature that conforms to the\nspec (that is, un-prefixed and not under an alternative name —\nthough possibly requiring a runtime flag or preference to be set)."
         },
         "altname": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/EngineNames"
+            "$ref": "#/definitions/Engines"
           },
           "description": "Names of engines with support for the feature implemented under a\nwholly different name (in contrast to just being prefixed)."
         },
         "needsflag": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/EngineNames"
+            "$ref": "#/definitions/Engines"
           },
           "description": "Names of engines with support for the feature that requires setting\na runtime flag or preference."
         },
         "partial": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/EngineNames"
+            "$ref": "#/definitions/Engines"
           },
           "description": "Names of engines with support for the feature that differs from the\nspec in a way that may cause compatibility problems."
         },
         "prefixed": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/EngineNames"
+            "$ref": "#/definitions/Engines"
           },
           "description": "Names of engines with support for the feature that requires adding\na prefix to the standard feature name defined in the spec."
         },
         "support": {
           "anyOf": [
             {
-              "$ref": "#/definitions/SupportBlock"
+              "$ref": "#/definitions/Support"
             },
             {
               "type": "null"
@@ -114,7 +114,7 @@
       "additionalProperties": false,
       "description": "Each object for a feature has data from the MDN article for the feature,\nalong with data from BCD https://github.com/mdn/browser-compat-data/."
     },
-    "EngineNames": {
+    "Engines": {
       "type": "string",
       "enum": [
         "blink",
@@ -122,77 +122,77 @@
         "webkit"
       ]
     },
-    "SupportBlock": {
+    "Support": {
       "type": "object",
       "properties": {
         "chrome": {
-          "$ref": "#/definitions/SupportDetails"
+          "$ref": "#/definitions/SupportData"
         },
         "chrome_android": {
-          "$ref": "#/definitions/SupportDetails"
+          "$ref": "#/definitions/SupportData"
         },
         "edge": {
-          "$ref": "#/definitions/SupportDetails"
+          "$ref": "#/definitions/SupportData"
         },
         "edge_blink": {
-          "$ref": "#/definitions/SupportDetails"
+          "$ref": "#/definitions/SupportData"
         },
         "firefox": {
-          "$ref": "#/definitions/SupportDetails"
+          "$ref": "#/definitions/SupportData"
         },
         "firefox_android": {
-          "$ref": "#/definitions/SupportDetails"
+          "$ref": "#/definitions/SupportData"
         },
         "ie": {
-          "$ref": "#/definitions/SupportDetails"
+          "$ref": "#/definitions/SupportData"
         },
         "nodejs": {
-          "$ref": "#/definitions/SupportDetails"
+          "$ref": "#/definitions/SupportData"
         },
         "opera": {
-          "$ref": "#/definitions/SupportDetails"
+          "$ref": "#/definitions/SupportData"
         },
         "opera_android": {
-          "$ref": "#/definitions/SupportDetails"
+          "$ref": "#/definitions/SupportData"
         },
         "qq_android": {
-          "$ref": "#/definitions/SupportDetails"
+          "$ref": "#/definitions/SupportData"
         },
         "safari": {
-          "$ref": "#/definitions/SupportDetails"
+          "$ref": "#/definitions/SupportData"
         },
         "safari_ios": {
-          "$ref": "#/definitions/SupportDetails"
+          "$ref": "#/definitions/SupportData"
         },
         "samsunginternet_android": {
-          "$ref": "#/definitions/SupportDetails"
+          "$ref": "#/definitions/SupportData"
         },
         "uc_android": {
-          "$ref": "#/definitions/SupportDetails"
+          "$ref": "#/definitions/SupportData"
         },
         "uc_chinese_android": {
-          "$ref": "#/definitions/SupportDetails"
+          "$ref": "#/definitions/SupportData"
         },
         "webview_android": {
-          "$ref": "#/definitions/SupportDetails"
+          "$ref": "#/definitions/SupportData"
         }
       },
       "additionalProperties": false
     },
-    "SupportDetails": {
+    "SupportData": {
       "anyOf": [
         {
-          "$ref": "#/definitions/SupportStatement"
+          "$ref": "#/definitions/SupportDetails"
         },
         {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/SupportStatement"
+            "$ref": "#/definitions/SupportDetails"
           }
         }
       ]
     },
-    "SupportStatement": {
+    "SupportDetails": {
       "type": "object",
       "properties": {
         "version_added": {

--- a/.mdn-spec-links.ts
+++ b/.mdn-spec-links.ts
@@ -37,31 +37,31 @@ export interface Feature {
      * spec (that is, un-prefixed and not under an alternative name —
      * though possibly requiring a runtime flag or preference to be set).
      */
-    engines: EngineNames[];
+    engines: Engines[];
     /**
      * Names of engines with support for the feature implemented under a
      * wholly different name (in contrast to just being prefixed).
      */
-    altname?: EngineNames[];
+    altname?: Engines[];
     /**
      * Names of engines with support for the feature that requires setting
      * a runtime flag or preference.
      */
-    needsflag?: EngineNames[];
+    needsflag?: Engines[];
     /**
      * Names of engines with support for the feature that differs from the
      * spec in a way that may cause compatibility problems.
      */
-    partial?: EngineNames[];
+    partial?: Engines[];
     /**
      * Names of engines with support for the feature that requires adding
      * a prefix to the standard feature name defined in the spec.
      */
-    prefixed?: EngineNames[];
+    prefixed?: Engines[];
     /**
      * Per-browser data about support for the feature.
      */
-    support: SupportBlock | null;
+    support: Support | null;
     /**
      * The caniuse.com shortname for the feature, along with the title of
      * the caniuse.com table (page) for the feature.
@@ -69,31 +69,32 @@ export interface Feature {
     caniuse?:  { feature: string, title: string };
 }
 
-export type EngineNames = "blink" | "gecko" | "webkit";
+export type Engines = "blink" | "gecko" | "webkit";
 
-export type SupportDetails = SupportStatement | SupportStatement[];
+type Browsers =
+    "chrome"
+    | "chrome_android"
+    | "edge"
+    | "edge_blink"
+    | "firefox"
+    | "firefox_android"
+    | "ie"
+    | "nodejs"
+    | "opera"
+    | "opera_android"
+    | "qq_android"
+    | "safari"
+    | "safari_ios"
+    | "samsunginternet_android"
+    | "uc_android"
+    | "uc_chinese_android"
+    | "webview_android";
 
-export interface SupportBlock {
-    chrome?:                  SupportDetails;
-    chrome_android?:          SupportDetails;
-    edge?:                    SupportDetails;
-    edge_blink?:              SupportDetails;
-    firefox?:                 SupportDetails;
-    firefox_android?:         SupportDetails;
-    ie?:                      SupportDetails;
-    nodejs?:                  SupportDetails;
-    opera?:                   SupportDetails;
-    opera_android?:           SupportDetails;
-    qq_android?:              SupportDetails;
-    safari?:                  SupportDetails;
-    safari_ios?:              SupportDetails;
-    samsunginternet_android?: SupportDetails;
-    uc_android?:              SupportDetails;
-    uc_chinese_android?:      SupportDetails;
-    webview_android?:         SupportDetails;
-}
+export type Support = Partial<Record <Browsers, SupportData>>;
 
-export interface SupportStatement {
+export type SupportData = SupportDetails | SupportDetails[]
+
+export interface SupportDetails {
     /**
      * Either: (1) a browser version number (the first version of the
      * browser to add support for the feature), or (2) boolean true to

--- a/.mdn-spec-links.ts
+++ b/.mdn-spec-links.ts
@@ -1,0 +1,151 @@
+/**
+ * Each top-level entry in our data is an object with a single key: A
+ * fragment ID from a spec. Each top-level entry associates its spec
+ * fragment ID with one or more objects holding data about a feature.
+ */
+export interface MDNSpecLink {
+  [specLinkFragmentID: string]: Feature[];
+}
+
+/**
+ * Each object for a feature has data from the MDN article for the feature,
+ * along with data from BCD https://github.com/mdn/browser-compat-data/.
+ */
+export interface Feature {
+    /**
+     * Name of the feature (interface, method, or property name); from BCD.
+     */
+    name: string;
+    /**
+     * Filename of the BCD file containing the data for the feature.
+     */
+    filename: string | null;
+    /**
+     * Title of the MDN article for the feature.
+     */
+    title: string;
+    /**
+     * Slug (URL path) of the MDN article for the feature.
+     */
+    slug: string;
+    /**
+     * First paragraph or "seoSummary" of the MDN article for the feature.
+     */
+    summary: string;
+    /**
+     * Names of engines with support for the feature that conforms to the
+     * spec (that is, un-prefixed and not under an alternative name —
+     * though possibly requiring a runtime flag or preference to be set).
+     */
+    engines: EngineNames[];
+    /**
+     * Names of engines with support for the feature implemented under a
+     * wholly different name (in contrast to just being prefixed).
+     */
+    altname?: EngineNames[];
+    /**
+     * Names of engines with support for the feature that requires setting
+     * a runtime flag or preference.
+     */
+    needsflag?: EngineNames[];
+    /**
+     * Names of engines with support for the feature that differs from the
+     * spec in a way that may cause compatibility problems.
+     */
+    partial?: EngineNames[];
+    /**
+     * Names of engines with support for the feature that requires adding
+     * a prefix to the standard feature name defined in the spec.
+     */
+    prefixed?: EngineNames[];
+    /**
+     * Per-browser data about support for the feature.
+     */
+    support: SupportBlock | null;
+    /**
+     * The caniuse.com shortname for the feature, along with the title of
+     * the caniuse.com table (page) for the feature.
+     */
+    caniuse?:  { feature: string, title: string };
+}
+
+export type EngineNames = "blink" | "gecko" | "webkit";
+
+export type SupportDetails = SupportStatement | SupportStatement[];
+
+export interface SupportBlock {
+    chrome?:                  SupportDetails;
+    chrome_android?:          SupportDetails;
+    edge?:                    SupportDetails;
+    edge_blink?:              SupportDetails;
+    firefox?:                 SupportDetails;
+    firefox_android?:         SupportDetails;
+    ie?:                      SupportDetails;
+    nodejs?:                  SupportDetails;
+    opera?:                   SupportDetails;
+    opera_android?:           SupportDetails;
+    qq_android?:              SupportDetails;
+    safari?:                  SupportDetails;
+    safari_ios?:              SupportDetails;
+    samsunginternet_android?: SupportDetails;
+    uc_android?:              SupportDetails;
+    uc_chinese_android?:      SupportDetails;
+    webview_android?:         SupportDetails;
+}
+
+export interface SupportStatement {
+    /**
+     * Either: (1) a browser version number (the first version of the
+     * browser to add support for the feature), or (2) boolean true to
+     * indicate just that the browser supports the feature (but the first
+     * version to add support for it is unknown), or (3) boolean false to
+     * indicate the browser doesn't support the feature, or else (4) null
+     * to indicate it's unknown whether the browser supports the feature.
+     */
+    version_added: string | boolean | null;
+    /**
+     * Either: (1) a browser version number (the version of the browser
+     * which dropped support for the feature), or (2) boolean true to
+     * indicate just that the feature was dropped from the browser (but the
+     * first version to drop support for it is unknown). (Boolean false and
+     * null are also allowed as values, but the semantics are undefined.)
+     */
+    version_removed?: string | boolean | null;
+    /**
+     * Alternative name for the feature, for cases of a feature implemented
+     * under a wholly different name (in contrast to just being prefixed).
+     */
+    alternative_name?: string;
+    /**
+     * Data about flags needed to enable support for the feature.
+     */
+    flags?: Flag[];
+    /**
+     * Additional/noteworthy information about support for the feature.
+     */
+    notes?: string | string[];
+    /**
+     * Boolean indicating whether support for the feature deviates from the
+     * specification in a way that may cause compatibility problems.
+     */
+    partial_implementation?: boolean;
+    /**
+     * Prefix that must be added to the feature name defined in the spec in
+     * order to enable support. Includes any leading/trailing dashes.
+     */
+    prefix?: string;
+}
+
+export interface Flag {
+    /**
+     * The name of the flag or preference that must be set in order to
+     * enable support for the feature.
+     */
+    name: string;
+    type: "preference" | "runtime_flag";
+    /**
+     * The value to which the specified flag must be set in order to enable
+     * support for the feature.
+     */
+    value_to_set?: string;
+}

--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,6 @@ index.html: README.md
 	done
 	$(GRIP) --title=$< --export $<.tmp - > $@
 	$(RM) $<.tmp
+
+.mdn-spec-links.schema.json: .mdn-spec-links.ts
+	ts-json-schema-generator --path $< --unstable --type MDNSpecLink --out $@

--- a/README.md
+++ b/README.md
@@ -8,3 +8,8 @@ All the data here is generated. So you don’t want to edit anything here
 directly; instead you’d need to edit the upstream data at
 https://github.com/mdn/browser-compat-data, and the content of
 https://developer.mozilla.org/docs/Web articles.
+
+https://github.com/w3c/mdn-spec-links/blob/master/.mdn-spec-links.ts
+defines the datatypes and structure of the JSON data. The generated
+https://github.com/w3c/mdn-spec-links/blob/master/.mdn-spec-links.schema.json
+file is a JSON Schema that provides the same definitions.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ directly; instead you’d need to edit the upstream data at
 https://github.com/mdn/browser-compat-data, and the content of
 https://developer.mozilla.org/docs/Web articles.
 
-https://github.com/w3c/mdn-spec-links/blob/master/.mdn-spec-links.ts
-defines the datatypes and structure of the JSON data. The generated
-https://github.com/w3c/mdn-spec-links/blob/master/.mdn-spec-links.schema.json
+[.mdn-spec-links.ts](https://github.com/w3c/mdn-spec-links/blob/HEAD/.mdn-spec-links.ts)
+defines the data-types and structure of the JSON data as a TypeScript declaration. The generated
+[.mdn-spec-links.schema.json](https://github.com/w3c/mdn-spec-links/blob/HEAD/.mdn-spec-links.schema.json)
 file is a JSON Schema that provides the same definitions.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ directly; instead you’d need to edit the upstream data at
 https://github.com/mdn/browser-compat-data, and the content of
 https://developer.mozilla.org/docs/Web articles.
 
-[.mdn-spec-links.ts](https://github.com/w3c/mdn-spec-links/blob/HEAD/.mdn-spec-links.ts)
-defines the data-types and structure of the JSON data as a TypeScript declaration. The generated
-[.mdn-spec-links.schema.json](https://github.com/w3c/mdn-spec-links/blob/HEAD/.mdn-spec-links.schema.json)
-file is a JSON Schema that provides the same definitions.
+[.mdn-spec-links.ts][1] defines the data-types and structure of the JSON
+data as a TypeScript declaration. The [.mdn-spec-links.schema.json][2]
+file, generated from the TypeScript declaration, is a JSON Schema that
+provides the same definitions.
+
+[1]: https://github.com/w3c/mdn-spec-links/blob/HEAD/.mdn-spec-links.ts
+[2]: https://github.com/w3c/mdn-spec-links/blob/HEAD/.mdn-spec-links.schema.json


### PR DESCRIPTION
This change adds:

* A TypeScript declaration that defines the datatypes and structure of the mdn-spec-links JSON data.

* A JSON Schema generated from the TypeScript declaration.

Fixes https://github.com/w3c/mdn-spec-links/issues/3.