### PR TITLE
Fix anchors

### DIFF
--- a/cssom.json
+++ b/cssom.json
@@ -680,7 +680,7 @@
             "title": "CSSNamespaceRule"
         }
     ],
-    "dom-cssgroupingrule-selectortext": [
+    "dom-csspagerule-selectortext": [
         {
             "engines": [
                 "blink",
@@ -729,7 +729,7 @@
             "title": "CSSPageRule: selectorText property"
         }
     ],
-    "dom-cssgroupingrule-style": [
+    "dom-csspagerule-style": [
         {
             "engines": [
                 "blink",


### PR DESCRIPTION
Two anchors were pointing to (nonexistent) CSSGroupingRule attributes, when they're clearly meant to point to CSSPageRule.