### PR TITLE
Update spec-generator URLs

### DIFF
--- a/.spec-urls-make.js
+++ b/.spec-urls-make.js
@@ -157,7 +157,7 @@ const processSpecURL = async (
   let requestURL = specURL;
   if (respecRawSpecs.includes(requestURL)) {
     requestURL =
-      "https://labs.w3.org/spec-generator/?type=respec&url=" + requestURL;
+      "https://www.w3.org/publications/spec-generator/?type=respec&url=" + requestURL;
   }
   const contents = getRemoteContents(specURL, requestURL, seconds);
   if (contents && contents.match(/respec-w3c-/)) {
@@ -198,8 +198,8 @@ const processSpecURL = async (
     requestURL = originalURL;
   }
 
-  if (requestURL.startsWith("https://labs.w3.org/spec-generator/")) {
-    requestURL = requestURL.substring(52);
+  if (requestURL.startsWith("https://www.w3.org/publications/spec-generator/")) {
+    requestURL = requestURL.substring(64);
   }
 
   if (specJSONfile === "mathml.json") {

--- a/.spec-urls-make.js
+++ b/.spec-urls-make.js
@@ -148,6 +148,9 @@ const getRemoteContents = (specURL, requestURL, seconds) => {
   }
 };
 
+const specGeneratorPrefix =
+  "https://www.w3.org/publications/spec-generator/?type=respec&url=";
+
 const processSpecURL = async (
   specURL,
   specJSONfile,
@@ -156,8 +159,7 @@ const processSpecURL = async (
 ) => {
   let requestURL = specURL;
   if (respecRawSpecs.includes(requestURL)) {
-    requestURL =
-      "https://www.w3.org/publications/spec-generator/?type=respec&url=" + requestURL;
+    requestURL = specGeneratorPrefix + requestURL;
   }
   const contents = getRemoteContents(specURL, requestURL, seconds);
   if (contents && contents.match(/respec-w3c-/)) {
@@ -198,8 +200,8 @@ const processSpecURL = async (
     requestURL = originalURL;
   }
 
-  if (requestURL.startsWith("https://www.w3.org/publications/spec-generator/")) {
-    requestURL = requestURL.substring(64);
+  if (requestURL.startsWith(specGeneratorPrefix)) {
+    requestURL = requestURL.substring(specGeneratorPrefix.length);
   }
 
   if (specJSONfile === "mathml.json") {


### PR DESCRIPTION
This updates spec-generator URLs to use the new subdomain/path announced in https://lists.w3.org/Archives/Public/spec-prod/2025OctDec/0008.html.

This PR includes 2 commits: the first makes the smallest required changes, while the second makes the `substring` call less brittle rather than hard-coding its offset, which also makes its purpose clearer.